### PR TITLE
refactor: renamed ImmutableXSdk to ImmutableXCore

### DIFF
--- a/docs/sdks/Core SDK Kotlin JVM.md
+++ b/docs/sdks/Core SDK Kotlin JVM.md
@@ -35,7 +35,7 @@ dependencies {
 ```
 4. Set the correct environment (Ropsten or Production/Mainnet)
 ```kt
-ImmutableXSdk.setBase(ImmutableXBase.Ropsten)
+ImmutableXCore.setBase(ImmutableXBase.Ropsten)
 ```
 
 ## Usage


### PR DESCRIPTION
The object `ImmutableXSdk` was renamed to `ImmutableXCore` in the 0.5.2 release of the SDK. 

This change needs to be reflected in the docs.

## Description

Describe your pull request here.

## Resolved issues
Jira:

### Before submitting the PR, please consider the follow:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.