### PR TITLE
Docs: Update `/onboarding` hyperlinks to valid Markdown

### DIFF
--- a/docs/guides/onboarding/index.md
+++ b/docs/guides/onboarding/index.md
@@ -5,7 +5,7 @@ slug: "/onboarding"
 Below is a high-level overview of the steps required to onboard with Immutable X.
 
 # Before you start
-The Immutable X test environment uses Ropsten. If you haven’t already, get [prepared to test](./getting-started-guide.md#prepare-to-test) with an Ethereum wallet and some test ETH. You also need to [register as a user(getting-started-guide.md#register-a-user-account) before you can register a project.
+The Immutable X test environment uses Ropsten. If you haven’t already, get [prepared to test](./getting-started-guide.md#prepare-to-test) with an Ethereum wallet and some test ETH. You also need to [register as a user](getting-started-guide.md#register-a-user-account) before you can register a project.
 :::info Common Terms
 The following explains a couple of Immutable X terms used throughout our guides:
 

--- a/docs/guides/onboarding/index.md
+++ b/docs/guides/onboarding/index.md
@@ -5,7 +5,7 @@ slug: "/onboarding"
 Below is a high-level overview of the steps required to onboard with Immutable X.
 
 # Before you start
-The Immutable X test environment uses Ropsten. If you haven’t already, get [prepared to test]   ./getting-started-guide.md#prepare-to-test) with an Ethereum wallet and some test ETH. You also need to [register as a user(getting-started-guide.md#register-a-user-account) before you can register a project.
+The Immutable X test environment uses Ropsten. If you haven’t already, get [prepared to test](./getting-started-guide.md#prepare-to-test) with an Ethereum wallet and some test ETH. You also need to [register as a user(getting-started-guide.md#register-a-user-account) before you can register a project.
 :::info Common Terms
 The following explains a couple of Immutable X terms used throughout our guides:
 


### PR DESCRIPTION
## Description
When reviewing the onboarding documentation at https://docs.x.immutable.com/docs/onboarding it was clear that the markdown used for the `./getting-started-guide.md#prepare-to-test` link was missing a parenthese so it could render appropriately on the gitbook docs.

## Resolved issues
resolves #34 

### Before submitting the PR, please consider the follow:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.