### PR TITLE
fix(api): make dark mode font colour lighter

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -509,6 +509,10 @@ button.clean-btn.navbar-sidebar__close>svg {
   line-height: 20px !important;
 }
 
+[data-theme='dark'] .elements-container :is(.token.string, .token.function, .token.property) {
+  color: var(--ifm-color-primary) !important;
+}
+
 .custom_sidebar_menu hr {
   width: 100% !important;
   margin: 26.4px !important;

--- a/src/pages/reference.tsx
+++ b/src/pages/reference.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-
 import Layout from '@theme/Layout';
 
 export default function APIPage() {
@@ -32,7 +31,7 @@ export default function APIPage() {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { API } = require('@stoplight/elements');
           return (
-            <>
+            <div className="elements-container">
               <API
                 apiDescriptionUrl="https://api.ropsten.x.immutable.com/openapi-docs"
                 router="hash"
@@ -40,7 +39,7 @@ export default function APIPage() {
                 layout="sidebar"
                 hideSchemas
               />
-            </>
+            </div>
           );
         }}
       </BrowserOnly>


### PR DESCRIPTION
## Description
If you look at our API documentation in dark mode ([example](https://docs.x.immutable.com/reference/#/operations/getMetadataSchema)), you will see that the request and response samples are extremely difficult to read. This is due to a bug on stoplight where the colour choice is not great for dark mode. [There is an issue outstanding on the repo ](https://github.com/stoplightio/elements/issues/2188) however until that is fixed, this solution bandaids this problem.

After:
![image](https://user-images.githubusercontent.com/25076909/180138487-04eceb1f-bb98-497a-9077-eeabe2c95bb0.png)

## Resolved issues
Jira: https://immutable.atlassian.net/browse/DX-889

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team