### PR TITLE
fix: redirect old kotlin docs

### DIFF
--- a/src/pages/docs/imx-core-sdk-kotlin-jvm/index.tsx
+++ b/src/pages/docs/imx-core-sdk-kotlin-jvm/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+export default function ImxCoreSdkKotlin() {
+  return <Redirect to="/sdk-docs/core-sdk-kotlin/overview" />;
+}

--- a/src/pages/docs/imx-core-sdk-ts/index.tsx
+++ b/src/pages/docs/imx-core-sdk-ts/index.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { Redirect } from '@docusaurus/router';
 
 export default function ImxCoreSdkTs() {
-  return <Redirect to="/sdk-docs/core-sdk-ts/" />;
+  return <Redirect to="/sdk-docs/core-sdk-ts/overview" />;
 }


### PR DESCRIPTION
## Description

Setup redirection from old Kotlin SDK docs URL to new SDK docs.

## Resolved issues

Jira: https://immutable.atlassian.net/browse/DX-1047

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team