### PR TITLE
[DX-1061] fix: replace code flash with SDK landing page

### DIFF
--- a/docs/main/sdks.mdx
+++ b/docs/main/sdks.mdx
@@ -1,14 +1,39 @@
 ---
-id: "sdks"
-title: "SDKs"
-slug: "/sdks"
-description: "Core SDK TypeScript"
+id: 'sdks'
+title: 'Immutable X SDKs'
+slug: '/sdks'
+description: 'Immutable X SDKs'
 ---
 
-# Core SDK TypeScript - Home
+import Button from '@site/src/components/Button';
+import RightArrowIcon from '@site/static/icons/RightArrow';
+import styles from '@site/src/components/Article/styles.module.css';
 
-import {Redirect} from '@docusaurus/router';
+## Immutable Core SDKs
 
-const Home = () => {
-  return <Redirect to="/sdk-docs/core-sdk-ts" />;
-};
+The Immutable Core SDKs provide convenient access to the Immutable APIs and Ethereum Contract methods for applications that want to integrate with Immutable. The Core SDK is presently available in Typescript and Kotlin/JVM will be available in many languages in the near future.
+
+<a href="/sdk-docs/core-sdk-ts/overview">
+  <Button>
+    {'Immutable Core SDK - Typescript '}
+    <RightArrowIcon className={styles.ctaIcon} />
+  </Button>
+</a>
+<br />
+<br />
+<a href="/sdk-docs/core-sdk-kotlin/overview">
+  <Button>
+    {'Immutable Core SDK - Kotlin/JVM '}
+    <RightArrowIcon className={styles.ctaIcon} />
+  </Button>
+</a>
+
+## Open API Specification
+
+Immutable's Open API specification empowers developers to be able to interact efficiently with our APIs by supporting the automatic client generation in many languages.
+
+<a href="https://github.com/immutable/imx-core-sdk/blob/main/openapi.json">
+  <Button>
+    Immutable Open API Spec <RightArrowIcon className={styles.ctaIcon} />
+  </Button>
+</a>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,7 +136,7 @@ const configuration = {
             label: 'APIs',
           },
           {
-            to: '/sdk-docs/core-sdk-ts/overview',
+            to: '/docs/sdks',
             position: 'left',
             label: 'SDKs',
           },


### PR DESCRIPTION
## Description

Navigating to `/docs/sdks` produces a code flash when the page first loads. This is caused by an internal React redirect.

The solution was to replace the redirect at `/docs/sdks/` with a SDKs landing page.

Note. the main nav has been configured to point to the new landing page instead of automatically taking the user to the TypeScript SDK docs.

## Resolved issues

Jira: https://immutable.atlassian.net/browse/DX-1061

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team