### PR TITLE
[DX-1063] fix: switcher incorrect selected SDK bug

### DIFF
--- a/docs/main/sdks.mdx
+++ b/docs/main/sdks.mdx
@@ -4,37 +4,14 @@ title: 'Immutable X SDKs'
 slug: '/sdks'
 description: 'Immutable X SDKs'
 ---
-
-import Button from '@site/src/components/Button';
-import RightArrowIcon from '@site/static/icons/RightArrow';
-import styles from '@site/src/components/Article/styles.module.css';
+import SdkButtonList from '@site/src/components/SdkButtonList';
+import articleStyles from '@site/src/components/Article/styles.module.css';
 
 ## Immutable Core SDKs
 
 The Immutable Core SDKs provide convenient access to the Immutable APIs and Ethereum Contract methods for applications that want to integrate with Immutable. The Core SDK is presently available in Typescript and Kotlin/JVM will be available in many languages in the near future.
 
-<a href="/sdk-docs/core-sdk-ts/overview">
-  <Button>
-    {'Immutable Core SDK - Typescript '}
-    <RightArrowIcon className={styles.ctaIcon} />
-  </Button>
-</a>
-<br />
-<br />
-<a href="/sdk-docs/core-sdk-kotlin/overview">
-  <Button>
-    {'Immutable Core SDK - Kotlin/JVM '}
-    <RightArrowIcon className={styles.ctaIcon} />
-  </Button>
-</a>
-<br />
-<br />
-<a href="/sdk-docs/core-sdk-swift/overview">
-  <Button>
-    {'Immutable Core SDK - Swift '}
-    <RightArrowIcon className={styles.ctaIcon} />
-  </Button>
-</a>
+<SdkButtonList />
 
 ## Open API Specification
 
@@ -42,6 +19,6 @@ Immutable's Open API specification empowers developers to be able to interact ef
 
 <a href="https://github.com/immutable/imx-core-sdk/blob/main/openapi.json">
   <Button>
-    Immutable Open API Spec <RightArrowIcon className={styles.ctaIcon} />
+    Immutable Open API Spec <RightArrowIcon className={articleStyles.ctaIcon} />
   </Button>
 </a>

--- a/src/components/SdkButtonList/index.tsx
+++ b/src/components/SdkButtonList/index.tsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import React from 'react';
+import { History } from 'history';
+import { useHistory } from 'react-router';
+import { SdkIdKey, SdkItem, sdks } from '@site/src/constants';
+import Button from '@site/src/components/Button';
+import RightArrowIcon from '@site/static/icons/RightArrow';
+import ArticleStyles from '@site/src/components/Article/styles.module.css';
+import styles from './styles.module.css';
+
+const SdkButtonList = () => {
+  const history: History = useHistory();
+
+  const handleClick = (sdk: SdkItem) => {
+    localStorage.setItem(SdkIdKey, JSON.stringify(sdk.id));
+    history.push(sdk.url);
+  };
+
+  return (
+    <div className={clsx(styles.sdkButtonList)}>
+      {sdks.map((sdk: SdkItem) => (
+        <Button
+          key={sdk.id}
+          onClick={() => handleClick(sdk)}
+          className={clsx(styles.sdkButton)}
+        >
+          {`${sdk.displayName} `}
+          <RightArrowIcon className={ArticleStyles.ctaIcon} />
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default SdkButtonList;

--- a/src/components/SdkButtonList/styles.module.css
+++ b/src/components/SdkButtonList/styles.module.css
@@ -1,0 +1,8 @@
+.sdkButtonList {
+  display: flex;
+  flex-direction: column;
+}
+
+.sdkButton {
+  margin: 0.8rem 0;
+}

--- a/src/components/SdkSwitcher/index.tsx
+++ b/src/components/SdkSwitcher/index.tsx
@@ -6,20 +6,25 @@ import { Listbox, Transition } from '@headlessui/react';
 import { SelectorIcon } from '@heroicons/react/solid';
 import VersionSwitcher from '@site/src/components/VersionSwitcher';
 import styles from './styles.module.css';
-import { sdks } from '@site/src/constants';
+import { SdkIdKey, SdkItem, SdkList, sdks } from '@site/src/constants';
 
-interface SdkItem {
-  id: number;
-  sdkId: string;
-  name: string;
-  url: string;
-}
-interface SdkList extends Array<SdkItem> {}
+// interface SdkItem {
+//   id: number;
+//   sdkId: string;
+//   name: string;
+//   url: string;
+// }
+// interface SdkList extends Array<SdkItem> {}
 
-const SDK_ID_KEY = 'imx-docs-core-sdk-id';
+// const SdkIdKey = 'imx-docs-core-sdk-id';
 
 const getSdkId = (sdkList: SdkList): number => {
-  const localId = parseInt(localStorage.getItem(SDK_ID_KEY)) || 0;
+  const val = localStorage.getItem(SdkIdKey);
+  console.log('val', val);
+
+  const localId = parseInt(localStorage.getItem(SdkIdKey)) || 0;
+
+  console.log('getSdkId.localId', localId);
 
   if (localId > sdkList.length - 1) {
     return 0;
@@ -33,7 +38,7 @@ const SdkSwitcher = () => {
   const [selectedSdk, setSelectedSdk] = useState<SdkItem>(sdks[sdkId]);
 
   const handleOnChange = (sdkItem: SdkItem) => {
-    localStorage.setItem(SDK_ID_KEY, sdkItem.id.toString());
+    localStorage.setItem(SdkIdKey, sdkItem.id.toString());
     setSelectedSdk(sdkItem);
     history.push(sdkItem.url);
   };

--- a/src/components/SdkSwitcher/index.tsx
+++ b/src/components/SdkSwitcher/index.tsx
@@ -8,23 +8,8 @@ import VersionSwitcher from '@site/src/components/VersionSwitcher';
 import styles from './styles.module.css';
 import { SdkIdKey, SdkItem, SdkList, sdks } from '@site/src/constants';
 
-// interface SdkItem {
-//   id: number;
-//   sdkId: string;
-//   name: string;
-//   url: string;
-// }
-// interface SdkList extends Array<SdkItem> {}
-
-// const SdkIdKey = 'imx-docs-core-sdk-id';
-
 const getSdkId = (sdkList: SdkList): number => {
-  const val = localStorage.getItem(SdkIdKey);
-  console.log('val', val);
-
   const localId = parseInt(localStorage.getItem(SdkIdKey)) || 0;
-
-  console.log('getSdkId.localId', localId);
 
   if (localId > sdkList.length - 1) {
     return 0;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,20 +1,34 @@
+export const SdkIdKey = 'imx-docs-core-sdk-id';
+export interface SdkItem {
+  id: number;
+  sdkId: string;
+  name: string;
+  displayName: string;
+  url: string;
+}
+
+export interface SdkList extends Array<SdkItem> {}
+
 export const sdks = [
   {
     id: 0,
     sdkId: 'sdks-core-sdk-ts',
     name: 'Core SDK TypeScript',
+    displayName: 'Immutable Core SDK - Typescript',
     url: '/sdk-docs/core-sdk-ts/overview',
   },
   {
     id: 1,
     sdkId: 'sdks-core-sdk-kotlin',
     name: 'Core SDK Kotlin',
+    displayName: 'Immutable Core SDK - Kotlin/JVM',
     url: '/sdk-docs/core-sdk-kotlin/overview',
   },
   {
     id: 2,
     sdkId: 'sdks-core-sdk-swift',
     name: 'Core SDK Swift',
+    displayName: 'Immutable Core SDK - Swift',
     url: '/sdk-docs/core-sdk-swift/overview',
   },
 ];


### PR DESCRIPTION
## Description

Fix the bug on the switcher when clicking the `SDK` nav link, then selecting an SDK, the switcher would display the name of the previously selected SDK in the switcher drop down.

This PR reworks some of the logic for remembering the selected SDK.

- Buttons on the SDK landing page now set the selected SDK state (in `localStorage`).
- SDK switcher should get correct selected SDK from `localStoreage`.
- SDK buttons on the landing page are now generated from the list of SDKs in `constants.ts`.

## Resolved issues

Jira: https://immutable.atlassian.net/browse/DX-1053

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team