### PR TITLE
fix(survicate): stringify teams trait value so survicate api accepts it

### DIFF
--- a/src/components/SurvicateWidget/index.tsx
+++ b/src/components/SurvicateWidget/index.tsx
@@ -99,14 +99,17 @@ const SurvicateWidget = () => {
 
     const teamOwners = getArticleTeamOwners();
 
-    // https://developers.survicate.com/javascript/configuration/
+    // https://developers.survicate.com/javascript/configuration/#disabling-automatic-targeting
     (function (opts) {
       opts.disableTargeting = true;
-      // Tag survey with article team ownership
-      opts.traits = {
-        ...(teamOwners.length > 0 && { imx_teams: teamOwners }),
-      };
     })((window._sva = window._sva || {}));
+
+    // https://developers.survicate.com/javascript/methods/#set-visitor-traits
+    if (teamOwners.length > 0) {
+      window._sva.setVisitorTraits({
+        imx_teams: teamOwners.toString(),
+      });
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR fixes a bug where Survicate's trait method call only accepts a string, where as we were trying to send an array of strings.

## Resolved issues
Jira: https://immutable.atlassian.net/browse/DX-1147

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating a documentation page, please also add or update the team ownership of that page (follow [this guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1947927045/Docs+ownership+registry#What-to-do-when-adding%2Fupdating-documentation-pages%3F)).
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team