### PR TITLE
fix(switcher): remove null padding from switcher component

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -336,8 +336,6 @@ div.navbar__item.dropdown.dropdown--hoverable {
   font-style: normal;
   font-size: 16px;
   line-height: 24px;
-  margin-right: 32px;
-  padding: 0;
 }
 
 div.navbar__item.dropdown.dropdown--hoverable .navbar__link {


### PR DESCRIPTION
## Description

Not walking past this litter. This fixes the lack of padding on the switcher/versions flexbox.

## Resolved issues
Jira: https://immutable.atlassian.net/browse/DX-1149

### Before submitting the PR, please consider the following:
- [x] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems the pull request solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating a documentation page, please also add or update the team ownership of that page (follow [this guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1947927045/Docs+ownership+registry#What-to-do-when-adding%2Fupdating-documentation-pages%3F)).
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team