### PR TITLE
[GMS-312] Metadata refresh documentation out of date

### DIFF
--- a/docs/main/guides/onboarding/metadata-schema-registration.mdx
+++ b/docs/main/guides/onboarding/metadata-schema-registration.mdx
@@ -83,12 +83,10 @@ Submitting the same metadata schema attribute will cause the error:
 }
 ```
 
-:::caution Metadata refreshing requires support
-While you can register your own collections and metadata on Goerli, you **cannot** execute a metadata refresh yourself. 
+:::success Refresh metadata
+In order to update asset metadata values based on the changes that you've made, you can [request a metadata refresh.](/docs/asset-metadata-refreshes) You will need to identify the tokens that need to be re-crawled, and the updates that have been made to them (via the [Metadata API](/docs/minting-on-immutable-x#metadata-api)).
 
-To refresh metadata changes, you need to [contact support](https://support.immutable.com) and identify the tokens that need to be re-crawled, and the updates that have been made to them.
-
-Requests may take up to 2 business days (AEST).
+We aim to process requests within 2 business days (AEST) but this can take longer depending on demand.
 :::
 
 ## Other attributes


### PR DESCRIPTION
## Description

https://immutable.atlassian.net/browse/GMS-312

The callout box says metadata refresh is manual. This needs to be updated to reflect the new metadata refresh feature.

## Resolved issues
Jira:

### Before submitting the PR, please consider the following:
- [ ] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [ ] The description should clearly illustrate what problems the pull request solves.
- [ ] Ensure that the commit messages follow our guidelines.
- [ ] Resolve merge conflicts (if any).
- [ ] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating a documentation page, please also add or update the team ownership of that page (follow [this guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1947927045/Docs+ownership+registry#What-to-do-when-adding%2Fupdating-documentation-pages%3F)).
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team