### PR TITLE
docs: The correct contract address for Goerli is 'sandbox'

### DIFF
--- a/docs/main/tutorials/zero-to-hero-nft-minting.md
+++ b/docs/main/tutorials/zero-to-hero-nft-minting.md
@@ -275,7 +275,7 @@ Next we will need to install packages needed for deploying our smart contract.
 
 ![Open the integrated terminal](/img/zero-to-hero/Integrated-Terminal.png 'Open the integrated terminal')
 
-3. Run `npm install --include=dev` and wait until the installation is completed
+3. Run `npm install --include=sandbox` and wait until the installation is completed
 4. Save your work
 
 ## Step 9: Deploy Contract


### PR DESCRIPTION
This is currently listed in the the readme for imx-contracts repo and is reflected inside deploy/utils.ts

## Description

Contracts readme states :
`Sandbox (Goerli) | 0x7917edb51ecd6cdb3f9854c3cc593f33de10c623`
https://github.com/immutable/imx-contracts/blob/main/README.md

Utils Looks for: 
```
 switch (network) {
        case 'dev':
            return '0x3e6e01355bB66925a65D372bf9c9f3835d9964fA';
        case 'sandbox':
            return '0x7917eDb51ecD6CdB3F9854c3cc593F33de10c623';
```
https://github.com/immutable/imx-contracts/blob/main/deploy/utils.ts

Problem:
And the tutorial states to use **dev** which will lead to an undesirable outcome.

