### PR TITLE
Update support options after partner confusion

### DIFF
--- a/docs/main/resources/contact.mdx
+++ b/docs/main/resources/contact.mdx
@@ -14,6 +14,13 @@ ImmutableX is open to all to build on, with no approvals required. If you want t
 
 <a href="https://www.immutable.com/contact"><Button>Contact Us</Button></a>
 
+
+## Contact Support
+To get help from our technical support team, email helpmebuild@immutable.com or reach out via the messenger at <a href="https://support.immutable.com">support.immutable.com</a> and select "I'm a developer with a question"
+
+<a href="https://support.immutable.com"><Button>Contact Support</Button></a>
+
+
 ## Project support
 
 ### Discord
@@ -29,7 +36,7 @@ You can also join the conversation, connect with other projects, and ask questio
 
 ## Apply for marketing support
 
-You can also [apply for marketing support](./marketing-support.mdx) for your project. Or, if you need help with an issue related to what you're building with ImmutableX, click below to submit an issue. Select *I have a question or issue related to building on ImmutableX* as your issue type.  
+You can also [apply for marketing support](./marketing-support.mdx) for your project. Or, if you need help with an issue related to what you're building with ImmutableX, click below to contact support.
 
 <a href="https://support.immutable.com"><Button>Contact Support</Button></a>
 


### PR DESCRIPTION
## Description

It's not clear which is the best channel to use to 'contact support' which is referenced in a number of pages in our docs. 

This update will make it more clear/more prominent.

