### PR TITLE
feat: added docs for Link Events

### DIFF
--- a/docs/main/guides/link-sdk/link-events.md
+++ b/docs/main/guides/link-sdk/link-events.md
@@ -12,7 +12,7 @@ keywords: [imx-wallets]
 
 ## Link Event Types
 
-The Link SDK will dispatch events on the window object with type `imx-link-info` from time to time. Currently this will only happen in the `link.buy()` flow when a user connects to a different game wallet before completing their purchase.
+The Link SDK will dispatch events on the window object with type `imx-link-info` from time to time. Currently this will only happen in the [Link.buy](./link-buy2.md) flow when a user connects to a different game wallet before completing their purchase.
 
 If this happens a Custom Event will be dispatched which will have the following shape:
 

--- a/docs/main/guides/link-sdk/link-events.md
+++ b/docs/main/guides/link-sdk/link-events.md
@@ -12,7 +12,7 @@ keywords: [imx-wallets]
 
 ## Link Event Types
 
-The Link SDK will dispatch events on the window obejct with type `imx-link-info` from time to time. 
+The Link SDK will dispatch events on the window object with type `imx-link-info` from time to time. 
 
 If this happens a Custom Event will be dispatched which will have the following shape:
 

--- a/docs/main/guides/link-sdk/link-events.md
+++ b/docs/main/guides/link-sdk/link-events.md
@@ -1,0 +1,79 @@
+---
+id: "link-events"
+title: "Link Events"
+slug: "/link-events"
+sidebar_position: 14
+keywords: [imx-wallets]
+---
+
+:::info
+  <h5>Link Events are available from imx-sdk version 1.40.0</h5>
+:::
+
+## Link Event Types
+
+The Link SDK will dispatch events on the window obejct with type `imx-link-info` from time to time. 
+
+If this happens a Custom Event will be dispatched which will have the following shape:
+
+``` typescript
+{
+  ...
+  detail: {
+    type: string;
+    payload?: any;
+  }
+}
+```
+
+The event detail types are defined in the ImxLinkInfoEventType enum. Note that more of these event types may be added in future.
+
+``` typescript
+enum ImxLinkInfoEventType {
+  WALLET_CONNECTION = 'wallet-connection',
+}
+```
+
+There is a flow in `link.buy()`, in which the user may connect to a different wallet before completing their purchase. The event dispatched will hold the details of the new wallet connection. Listening to this will enable your application to remain in sync with the currently connected wallet in Link.
+
+Here's an example event
+``` typescript
+{
+  "detail": {
+    "type": "wallet-connection",
+    "payload": {
+      "walletAddress": "0x...",
+      "starkPublicKey": "...",
+      "providerPreference": "metamask",
+      "ethNetwork": "goerli",
+      "email": ""
+    }
+  }
+}
+```
+
+## How to listen for events from Link
+
+The following code is an example of how to set up a listener for this event.
+
+``` typescript
+import { LINK_INFO_MESSAGE_TYPE, ImxLinkInfoEventType } from "@imtbl/imx-sdk"
+
+function linkInfoEventHandler(event:CustomEvent) => {
+  console.log("Type of the event, ", event.detail.type);
+  if(event.detail.payload) {
+    console.log("Payload of the event, ", event.detail.payload);
+  }
+
+  if(event.detail.type === ImxLinkInfoEventType.WALLET_CONNECTION){
+    // handle wallet-connection event
+  }
+}
+
+// Add the event listener
+window.addEventListener(LINK_INFO_MESSAGE_TYPE, linkInfoEventHandler);
+
+// At some other point you can remove the event listener with
+window.removeEventListener(LINK_INFO_MESSAGE_TYPE, linkInfoEventHandler);
+```
+

--- a/docs/main/guides/link-sdk/link-events.md
+++ b/docs/main/guides/link-sdk/link-events.md
@@ -12,7 +12,7 @@ keywords: [imx-wallets]
 
 ## Link Event Types
 
-The Link SDK will dispatch events on the window object with type `imx-link-info` from time to time. 
+The Link SDK will dispatch events on the window object with type `imx-link-info` from time to time. Currently this will only happen in the `link.buy()` flow when a user connects to a different game wallet before completing their purchase.
 
 If this happens a Custom Event will be dispatched which will have the following shape:
 
@@ -26,14 +26,15 @@ If this happens a Custom Event will be dispatched which will have the following 
 }
 ```
 
-The event detail types are defined in the ImxLinkInfoEventType enum. Note that more of these event types may be added in future.
+The event detail types are defined in the `ImxLinkInfoEventType` enum. 
+> Note that more of these event types may be added in future.
 
 ``` typescript
 enum ImxLinkInfoEventType {
   WALLET_CONNECTION = 'wallet-connection',
 }
 ```
-
+### Wallet Connection
 There is a flow in `link.buy()`, in which the user may connect to a different wallet before completing their purchase. The event dispatched will hold the details of the new wallet connection. Listening to this will enable your application to remain in sync with the currently connected wallet in Link.
 
 Here's an example event
@@ -59,7 +60,7 @@ The following code is an example of how to set up a listener for this event.
 ``` typescript
 import { LINK_INFO_MESSAGE_TYPE, ImxLinkInfoEventType } from "@imtbl/imx-sdk"
 
-function linkInfoEventHandler(event:CustomEvent) => {
+function linkInfoEventHandler(event: CustomEvent) => {
   console.log("Type of the event, ", event.detail.type);
   if(event.detail.payload) {
     console.log("Payload of the event, ", event.detail.payload);


### PR DESCRIPTION
## Description

Adding documentation for Link Events in the Link SDK section. 

In the `link.buy()` route, there is a flow (game wallet auto detect) in which a user might change their wallet connection before purchasing an asset. In this case an event will be raised by the Link SDK and these docs explain the event structure and how to listen to these types of info events.

## Resolved issues
[JIRA TICKET](https://immutable.atlassian.net/browse/WT-1021)

### Before submitting the PR, please consider the following:
- [ ] It's beneficial if your pull request references an issue used to discuss the pull request ahead of time. If you haven't previously created an issue, please create one and discuss your contribution with the maintainers.
- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [ ] The description should clearly illustrate what problems the pull request solves.
- [ ] Ensure that the commit messages follow our guidelines.
- [ ] Resolve merge conflicts (if any).
- [ ] Make sure that the current branch is up to date with the `main` branch.

### For internal Immutable developers:
- [ ] If you are adding or updating a documentation page, please also add or update the team ownership of that page (follow [this guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1947927045/Docs+ownership+registry#What-to-do-when-adding%2Fupdating-documentation-pages%3F)).
- [ ] If you are adding or updating documentation for an SDK, please make sure that you meet the requirements in [this doc](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide).
- [ ] Please obtain PR approval from all of the following:
    - Your tech lead (Fallback: Team lead or engineering manager)
    - Your product manager (Fallback: Group PM)
    - Another software engineer on your team